### PR TITLE
Add page for model registration

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -29,7 +29,10 @@ Read more about the :ref:`iamc-format`...
 Scenario databases hosted by IIASA
 ----------------------------------
 
+The *Energy, Climate and Environment* program (ECE) at IIASA is hosting many databases
+for the community to facilitate scenario analysis, model comparison and dissemination.
 
+Read more about the :ref:`scenario-databases`...
 
 Table of Contents
 -----------------
@@ -38,6 +41,7 @@ Table of Contents
    :maxdepth: 2
 
    iamc
+   scenario-databases
    software
 
 License & Source

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -1,0 +1,28 @@
+.. _scenario-databases:
+
+Scenario databases hosted by IIASA
+==================================
+
+The *Energy, Climate and Environment* program (ECE) at IIASA is hosting many databases
+for the community to facilitate scenario analysis, model comparison and dissemination.
+
+Model registration
+------------------
+
+To participate in a model comparison project using the IIASA scenario database infrastructure,
+you have to "register" your model. Model registration requires three specifications:
+
+* A model name including a *version number*, preferably using
+  `semantic versioning <https://semver.org>`_
+* | A list of region names as they should appear in the processed scenario data
+  | (e.g., after processing when sdatabase *Scenario Explorer* instance)
+* A model mapping to perform region aggregation from *native_regions* to
+  *common_regions* and renaming of model native regions (optional)
+
+Please follow the `Model registration user guide
+<https://nomenclature-iamc.readthedocs.io/en/stable/user_guide/model-registration.html>`_.
+
+Scenario submission
+-------------------
+
+Coming soon

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -14,8 +14,9 @@ you have to "register" your model. A model registration requires three specifica
 
 * A model name including a *version number*, preferably using
   `semantic versioning <https://semver.org>`_
-* | A list of region names as they should appear in the processed scenario data,
-  | i.e., after processing when submitting (uploading) to an IIASA database instance
+* A list or mapping of region names as they will be submitted (uploaded) to an IIASA
+  database instance by the modeling team, and how the region names should appear
+  in the processed scenario data
 * A model mapping to perform region aggregation from *native_regions* to
   *common_regions* and renaming of model native regions (optional)
 

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -10,14 +10,29 @@ Model registration
 ------------------
 
 To participate in a model comparison project using the IIASA scenario database infrastructure,
-you have to "register" your model. Model registration requires three specifications:
+you have to "register" your model. A model registration requires three specifications:
 
 * A model name including a *version number*, preferably using
   `semantic versioning <https://semver.org>`_
-* | A list of region names as they should appear in the processed scenario data
-  | (e.g., after processing when sdatabase *Scenario Explorer* instance)
+* | A list of region names as they should appear in the processed scenario data,
+  | i.e., after processing when submitting (uploading) to an IIASA database instance
 * A model mapping to perform region aggregation from *native_regions* to
   *common_regions* and renaming of model native regions (optional)
+
+Option 1) Registration using an Excel template
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you do not feel comfortable using GitHub, please use the `Excel template`_ and send
+it to the project managers by email.
+
+.. _`Excel template`: https://raw.githubusercontent.com/IAMconsortium/nomenclature/main/templates/model-registration-template.xlsx
+
+Option 2) Registration using a GitHub pull request
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The preferred approach for model registration is starting a GitHub pull request.
+Please contact the administrators if permissions for the project repository
+are required.
 
 Please follow the `Model registration user guide
 <https://nomenclature-iamc.readthedocs.io/en/stable/user_guide/model-registration.html>`_.


### PR DESCRIPTION
This PR starts a page to migrate over the IIASA-specific aspects of the user guide on model registration from the nomenclature docs.