### PR TITLE
Automate the copyright-year in the sphinx-config

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -14,11 +14,12 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = "ece-docs"
-copyright = "2023 IIASA"
+copyright = f"2023-{datetime.datetime.now().year} IIASA"
 author = "IIASA ECE Scenario Services Team"
 
 

--- a/index.rst
+++ b/index.rst
@@ -57,9 +57,8 @@ License & Source
 ----------------
 
 | The source code of this `Sphinx <http://sphinx-doc.org/>`_ project is available
-  at https://github.com/iiasa/ece-docs
-| under a `Creative Commons CC0 1.0 License
-  <https://github.com/iiasa/ece-docs/blob/main/LICENSE>`_.
+  at https://github.com/iiasa/ece-docs under a
+  `Creative Commons CC0 1.0 License <https://github.com/iiasa/ece-docs/blob/main/LICENSE>`_.
   The project is maintained by the *Scenario Services & Scientific Software* research theme
   at the IIASA Energy, Climate, and Environment program.
 | Visit https://software.ece.iiasa.ac.at for more information.


### PR DESCRIPTION
Just noticed the outdated copyright-year in the footer of the built page.