### PR TITLE
Add a section on legacy vs. ixmp4 databases

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -29,6 +29,7 @@ author = "IIASA ECE Scenario Services Team"
 # ones.
 extensions = [
     "sphinx.ext.intersphinx",
+    "sphinx.ext.autodoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/conf.py
+++ b/conf.py
@@ -29,7 +29,6 @@ author = "IIASA ECE Scenario Services Team"
 # ones.
 extensions = [
     "sphinx.ext.intersphinx",
-    "sphinx.ext.autodoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -105,7 +105,7 @@ packages. The queries depend on the type of the database.
 
 New *Scenario Explorer* instances (set up since 2025) use the *ScSe Apps infrastructure*
 and the **ixmp4** package as a database backend. You can list all **ixmp4** platforms
-hosted by IIASA (and to which you have access) using the :func:`pyam.iiasa.platforms()`.
+hosted by IIASA (and to which you have access) using :func:`pyam.iiasa.platforms()`.
 
 You can use :func:`pyam.read_iiasa()` for simple queries or the **ixmp4** package for
 connecting to a platform and execute more complex requests.

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -97,9 +97,8 @@ See :ref:`local-processing` for more information!
 Database API
 ------------
 
-You can query scenario data from an IIASA database instance using the function
-:func:`pyam.read_iiasa()` of the **pyam** package. More elaborate queries depend on the
-type of the database.
+You can query scenario data from an IIASA database instance via a Rest API or the Python
+packages. The queries depend on the type of the database.
 
 *Scenario Apps* and **ixmp4** instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,9 +107,8 @@ New *Scenario Explorer* instances (set up since 2025) use the *ScSe Apps infrast
 and the **ixmp4** package as a database backend. You can list all **ixmp4** platforms
 hosted by IIASA (and to which you have access) using the :func:`pyam.iiasa.platforms()`.
 
-
-You can use the **ixmp4** package for connecting to a platform and execute more complex
-queries.
+You can use :func:`pyam.read_iiasa()` for simple queries or the **ixmp4** package for
+connecting to a platform and execute more complex requests.
 
 .. code:: python
 
@@ -131,7 +129,8 @@ The *Scenario Explorer* infrastructure developed by the Scenario Services and Sc
 Software team from 2018 until 2024 uses the **ixmp** package (not **ixmp4**).
 
 You can use the **pyam** package to connect to a legacy *Scenario Explorer* instance
-and for example get a list of all scenarios in a database instance.
+and for example get a list of all scenarios in a database instance. You can also use
+:func:`pyam.read_iiasa()` to query scenario data from a legacy instance.
 
 .. code:: python
 
@@ -139,6 +138,8 @@ and for example get a list of all scenarios in a database instance.
 
     conn = pyam.iiasa.Connection("<instance>")
     conn.properties()
+
+    df = pyam.read_iiasa(conn, .. <filter_arguments>)
 
 Refer to :class:`pyam.iiasa.Connection` for more information.
 

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -106,9 +106,8 @@ type of the database.
 
 New *Scenario Explorer* instances (set up since 2025) use the *ScSe Apps infrastructure*
 and the **ixmp4** package as a database backend. You can list all **ixmp4** platforms
-hosted by IIASA (and to which you have access) using the following function:
+hosted by IIASA (and to which you have access) using the :func:`pyam.iiasa.platforms()`.
 
-.. autofunction:: pyam.iiasa.platforms
 
 You can use the **ixmp4** package for connecting to a platform and execute more complex
 queries.

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -60,14 +60,15 @@ Scenario version management
 ---------------------------
 
 When submitting a scenario (a.k.a. "run") to an IIASA database instance with an already
-existing model-scenario combination, the database will save the new submission as a new version
-of that run. The **version number** is incremented automatically and the new version
-will be automatically set as **default version** for that model-scenario name.
+existing model-scenario combination, the database will save the new submission as a new
+version of that run. The **version number** is incremented automatically and the new
+version will be automatically set as **default version** for that model-scenario name.
 
 To select other (non-default) versions, you can use the "Switch to Advanced View" button
 in the scenario-selection tab of an IIASA Scenario Explorer or you can use the
 :code:`default_only=False` option of the function :func:`pyam.read_iiasa()`
-or the **ixmp4** package (`read the docs <https://docs.ece.iiasa.ac.at/ixmp4>`_).
+or the **ixmp4** package (`read the docs <https://docs.ece.iiasa.ac.at/ixmp4>`_),
+see also the Section :ref:`database-api`.
 
 .. _scenario-processing:
 
@@ -90,3 +91,60 @@ See :ref:`local-processing` for more information!
 .. _GitHub: https://www.github.com
 
 .. _`https://github.com/iiasa/<project>-workflow`: https://github.com/iiasa
+
+.. _database-api:
+
+Database API
+------------
+
+You can query scenario data from an IIASA database instance using the function
+:func:`pyam.read_iiasa()` of the **pyam** package. More elaborate queries depend on the
+type of the database.
+
+*Scenario Apps* and **ixmp4** instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+New *Scenario Explorer* instances (set up since 2025) use the *ScSe Apps infrastructure*
+and the **ixmp4** package as a database backend. You can list all **ixmp4** platforms
+hosted by IIASA (and to which you have access) using the following function:
+
+.. autofunction:: pyam.iiasa.platforms
+
+You can use the **ixmp4** package for connecting to a platform and execute more complex
+queries.
+
+.. code:: python
+
+    import ixmp4
+
+    platform = ixmp4.Platform("<instance>")
+
+    # get a table of all "scenario runs" in the database
+    platform.runs.tabulate()
+
+    # get a table of all IAMC variables
+    platform.iamc.variables.tabulate()
+
+Legacy *Scenario Explorer* instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The *Scenario Explorer* infrastructure developed by the Scenario Services and Scientific
+Software team from 2018 until 2024 uses the **ixmp** package (not **ixmp4**).
+
+You can use the **pyam** package to connect to a legacy *Scenario Explorer* instance
+and for example get a list of all scenarios in a database instance.
+
+.. code:: python
+
+    import pyam
+
+    conn = pyam.iiasa.Connection("<instance>")
+    conn.properties()
+
+Refer to :class:`pyam.iiasa.Connection` for more information.
+
+.. note::
+
+    Read the `pyam documentation`_ for more information!
+
+.. _`pyam documentation`:  https://pyam-iamc.readthedocs.io/en/stable/tutorials/iiasa.html

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -98,7 +98,7 @@ Database API
 ------------
 
 You can query scenario data from an IIASA database instance via a Rest API or the Python
-packages. The queries depend on the type of the database.
+packages. The queries depend on the type of the database as explained below.
 
 *Scenario Apps* and **ixmp4** instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ and the **ixmp4** package as a database backend. You can list all **ixmp4** plat
 hosted by IIASA (and to which you have access) using :func:`pyam.iiasa.platforms()`.
 
 You can use :func:`pyam.read_iiasa()` for simple queries or the **ixmp4** package for
-connecting to a platform and execute more complex requests.
+connecting to a platform and executing other requests.
 
 .. code:: python
 
@@ -137,14 +137,18 @@ and for example get a list of all scenarios in a database instance. You can also
     import pyam
 
     conn = pyam.iiasa.Connection("<instance>")
+
+    # get a table of all scenarios in the database
     conn.properties()
 
+    # query scenario data and meta indicators from the database
     df = pyam.read_iiasa(conn, .. <filter_arguments>)
 
 Refer to :class:`pyam.iiasa.Connection` for more information.
 
 .. note::
 
-    Read the `pyam documentation`_ for more information!
+    Read the `pyam documentation`_ for more information about working with the IIASA
+    scenario databases and Python.
 
 .. _`pyam documentation`:  https://pyam-iamc.readthedocs.io/en/stable/tutorials/iiasa.html

--- a/scenario-databases.rst
+++ b/scenario-databases.rst
@@ -125,12 +125,10 @@ connecting to a platform and executing other requests.
 Legacy *Scenario Explorer* instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The *Scenario Explorer* infrastructure developed by the Scenario Services and Scientific
-Software team from 2018 until 2024 uses the **ixmp** package (not **ixmp4**).
-
 You can use the **pyam** package to connect to a legacy *Scenario Explorer* instance
-and for example get a list of all scenarios in a database instance. You can also use
-:func:`pyam.read_iiasa()` to query scenario data from a legacy instance.
+developed by the Scenario Services and Scientific Software team from 2018 until 2024.
+For example, you can get a list of all scenarios in a database instance. You can also
+use :func:`pyam.read_iiasa()` to query scenario data from a legacy instance.
 
 .. code:: python
 

--- a/user-guide/local-processing.rst
+++ b/user-guide/local-processing.rst
@@ -12,6 +12,8 @@ To run the project workflow locally, do the following:
 2. Git-clone the project repository
    (usually `https://github.com/iiasa/<project>-workflow`_)
 
+.. _`https://github.com/iiasa/<project>-workflow`: https://github.com/iiasa
+
 Then, run the workflow on a scenario data file using the terminal (from the folder where
 the project repository was cloned to).
 


### PR DESCRIPTION
I got several questions of the past week with people being confused why `pyam.iiasa.Connection()` didn't work as expected. So I added a new section to the ECE-docs database page...