### PR TITLE
Add link to repository for NUTS region GeoJSON files

### DIFF
--- a/standards/nuts.rst
+++ b/standards/nuts.rst
@@ -13,6 +13,9 @@ analysis and model comparison.
 
 The full list of NUTS regions is accessible in Eurostat's `Excel file`_.
 
+The geojson files for the NUTS 1, 2 and 3 regions are 
+available in the [scse-geojson](https://github.com/iiasa/scse-geojson) repository.
+
 .. code:: python
 
   from nomenclature import nuts


### PR DESCRIPTION
This PR adds a link to https://github.com/iiasa/scse-geojson repository for NUTS region geojson files in `nuts.rst`
@danielhuppmann 